### PR TITLE
add playsInline to video element (fixes experience on ios)

### DIFF
--- a/examples/image-tracking-multiple-targets/js/image-tracking.js
+++ b/examples/image-tracking-multiple-targets/js/image-tracking.js
@@ -2346,6 +2346,7 @@
       this.view = this.object.getComponent("view");
       navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: FacingModes[this.facingMode] } }).then((stream) => {
         this.video = document.createElement("video");
+        this.video.playsInline = true;
         this.video.srcObject = stream;
         this.video.addEventListener("loadedmetadata", () => {
           this.video.play();

--- a/examples/image-tracking/js/image-tracking.js
+++ b/examples/image-tracking/js/image-tracking.js
@@ -2346,6 +2346,7 @@
       this.view = this.object.getComponent("view");
       navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: FacingModes[this.facingMode] } }).then((stream) => {
         this.video = document.createElement("video");
+        this.video.playsInline = true;
         this.video.srcObject = stream;
         this.video.addEventListener("loadedmetadata", () => {
           this.video.play();

--- a/image-tracking.js
+++ b/image-tracking.js
@@ -22,6 +22,7 @@ WL.registerComponent('image-tracking', {
         navigator.mediaDevices.getUserMedia({audio: false, video: {facingMode: FacingModes[this.facingMode]}})
             .then(stream => {
                 this.video = document.createElement('video');
+                this.video.playsInline = true;
                 this.video.srcObject = stream;
                 this.video.addEventListener('loadedmetadata', () => {
                     this.video.play();


### PR DESCRIPTION
<video> element must have a playsInline attribute. Otherwise, iOS will try to play the video in full screen, which requires an extra user interaction and throws errors on video.play()